### PR TITLE
support play 2.3.7, with caveats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>net.raboof.play</groupId>
   <artifactId>play-pure-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>2.2.4</version>
+  <version>2.3.7-WHOA</version>
   <name>play-pure-maven-plugin Maven Mojo</name>
   <url>https://absurdhero.github.com/play-pure-maven-plugin</url>
   <description>Build Play Framework 2 Projects With Maven</description>
@@ -37,7 +37,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <play.version>2.2.4</play.version>
+    <play.version>2.3.7</play.version>
     <play2-scala.version>2.10</play2-scala.version>
     <scala.version>2.10.3</scala.version>
   </properties>
@@ -192,8 +192,8 @@
     </dependency>
     <dependency>
       <groupId>com.typesafe.play</groupId>
-      <artifactId>templates-compiler_${play2-scala.version}</artifactId>
-      <version>${play.version}</version>
+      <artifactId>twirl-compiler_${play2-scala.version}</artifactId>
+      <version>1.0.4</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.play</groupId>

--- a/src/main/java/com/nominum/build/TemplateCompilerMojo.java
+++ b/src/main/java/com/nominum/build/TemplateCompilerMojo.java
@@ -22,7 +22,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import play.templates.TemplateCompilationError;
+import play.twirl.compiler.TemplateCompilationError;
 import scala.collection.JavaConversions;
 
 import java.io.File;

--- a/src/test/resources/play-maven-project/pom.xml
+++ b/src/test/resources/play-maven-project/pom.xml
@@ -8,7 +8,7 @@
         <targetJdk>1.5</targetJdk>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <play.version>2.2.4</play.version>
+        <play.version>2.3.7</play.version>
         <play2-scala.version>2.10</play2-scala.version>
     </properties>
 
@@ -79,7 +79,7 @@
       <plugin>
           <groupId>net.raboof.play</groupId>
           <artifactId>play-pure-maven-plugin</artifactId>
-          <version>2.2.4</version>
+          <version>2.3.7-WHOA</version>
           <executions>
               <execution>
                   <goals>
@@ -109,8 +109,9 @@
         </dependency>
         <dependency>
             <groupId>com.typesafe.play</groupId>
-            <artifactId>templates_${play2-scala.version}</artifactId>
-            <version>${play.version}</version>
+            <artifactId>twirl-api_${play2-scala.version}</artifactId>
+            <!-- use a variable? -->
+            <version>1.0.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Here's the MVP version of play 2.3.7 support.

We replaced reflection with regular method calls because of default parameters making method signatures more painful. It might still be possible to look up the methods with reflection; apparently Scala implements default parameters by generating methods with predictable mangled names.

I don't know much about maven plugins; does the plugin use a classloader because it wants to use the template compiler for the version of play/twirl specified in the consuming project's pom.xml?