### PR TITLE
Add forJava parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,4 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-<parent>
-	<groupId>com.stratio</groupId>
-	<artifactId>parent</artifactId>
-	<version>0.1.0</version>
-</parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.raboof.play</groupId>
   <artifactId>play-pure-maven-plugin</artifactId>

--- a/src/main/java/com/nominum/build/ServerMojo.java
+++ b/src/main/java/com/nominum/build/ServerMojo.java
@@ -69,6 +69,10 @@ public class ServerMojo extends AbstractMojo implements FileListener {
     @Parameter(defaultValue="true", required=true)
     private Boolean generateReverseRouter;
 
+    /** whether is a Java or Scala project */
+    @Parameter(defaultValue="true", required=false)
+    private Boolean forJava;
+
     public void execute() throws MojoExecutionException, MojoFailureException {
 
         try {
@@ -175,7 +179,7 @@ public class ServerMojo extends AbstractMojo implements FileListener {
 
     private void compileTemplatesAndRoutes() throws MojoExecutionException {
         TemplateCompilerMojo.compileTemplatesAndRoutes(confDirectory,
-                generatedSourcesDirectory, project, sourceDirectory, generateReverseRouter);
+                generatedSourcesDirectory, project, sourceDirectory, generateReverseRouter, forJava);
     }
 
     public void fileCreated(FileChangeEvent event) throws Exception {

--- a/src/main/java/com/nominum/build/TemplateCompilerMojo.java
+++ b/src/main/java/com/nominum/build/TemplateCompilerMojo.java
@@ -61,12 +61,19 @@ public class TemplateCompilerMojo extends AbstractMojo {
     @Parameter(defaultValue="true", required=true)
     private Boolean generateReverseRouter;
 
+    @Parameter(defaultValue="true", required=false)
+    private Boolean forJava;
+
     public void execute()
         throws MojoExecutionException {
         try {
-            compileTemplatesAndRoutes(absolutePath(confDirectory),
-                absolutePath(generatedSourcesDirectory), project, absolutePath(sourceDirectory),
-                generateReverseRouter);
+            compileTemplatesAndRoutes(
+                    absolutePath(confDirectory),
+                    absolutePath(generatedSourcesDirectory),
+                    project,
+                    absolutePath(sourceDirectory),
+                    generateReverseRouter,
+                    forJava);
         } catch (TemplateCompilationError e) {
             String msg = String.format("Error in template %s:%s %s", e.source().getPath(), e.line(), e.message());
             throw new MojoExecutionException(msg);
@@ -74,7 +81,12 @@ public class TemplateCompilerMojo extends AbstractMojo {
     }
 
     /** This static method is usable by other Mojos */
-    public static void compileTemplatesAndRoutes(File confDirectory, File outputDir, MavenProject project, File sourceDir, boolean generateReverseRouter) throws MojoExecutionException {
+    public static void compileTemplatesAndRoutes(File confDirectory,
+                                                 File outputDir,
+                                                 MavenProject project,
+                                                 File sourceDir,
+                                                 boolean generateReverseRouter,
+                                                 boolean forJava) throws MojoExecutionException {
         project.addCompileSourceRoot(outputDir.getAbsolutePath());
 
         if (!outputDir.exists()) {
@@ -93,7 +105,7 @@ public class TemplateCompilerMojo extends AbstractMojo {
         }
 
         TemplateCompiler templateCompiler =
-                new TemplateCompiler(JavaConversions.asScalaBuffer(classpathFiles).toList(), true);
+                new TemplateCompiler(JavaConversions.asScalaBuffer(classpathFiles).toList(), forJava);
         templateCompiler.compile(sourceDir, outputDir);
 
     }


### PR DESCRIPTION
Currently is not possible to define whether you are working on a Scala or on a Java project.

The TemplateCompiler class will always generate the imports for a Java project and the compilation will fail for Scala projects.

This PR is aimed to fix this issue.