### PR TITLE
Update routes-compiler dependency to 2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     </dependency>
     <dependency>
       <groupId>com.typesafe.play</groupId>
-      <artifactId>routes-compiler_2.10</artifactId>
+      <artifactId>routes-compiler_2.11</artifactId>
       <version>${play.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Was required to compile routes with Play 2.4.6 and Scala 2.11.